### PR TITLE
Add Japanese variant of Universal control scheme

### DIFF
--- a/Settings/Settings.qml
+++ b/Settings/Settings.qml
@@ -61,7 +61,7 @@ FocusScope {
             [ dataText[lang].settings_general_logoVariant,  "logoVariant",  "",  "mono,color" ],
             [ dataText[lang].settings_general_region,  "region",  "",  "pal,ntsc,ntscj" ],
             [ dataText[lang].settings_general_hideOSC,  "osc",  "",  "No,Yes" ],
-            [ dataText[lang].settings_general_OSCScheme,  "controlScheme",  "",  "Universal,Japanese,XBOX,PS" ]
+            [ dataText[lang].settings_general_OSCScheme,  "controlScheme",  "",  "Universal,Universal-JP,XBOX,PS" ]
             ].forEach(function(element) {
                 append({
                             settingName: element[0],

--- a/Settings/Settings.qml
+++ b/Settings/Settings.qml
@@ -61,7 +61,7 @@ FocusScope {
             [ dataText[lang].settings_general_logoVariant,  "logoVariant",  "",  "mono,color" ],
             [ dataText[lang].settings_general_region,  "region",  "",  "pal,ntsc,ntscj" ],
             [ dataText[lang].settings_general_hideOSC,  "osc",  "",  "No,Yes" ],
-            [ dataText[lang].settings_general_OSCScheme,  "controlScheme",  "",  "Universal,XBOX,PS" ]
+            [ dataText[lang].settings_general_OSCScheme,  "controlScheme",  "",  "Universal,Japanese,XBOX,PS" ]
             ].forEach(function(element) {
                 append({
                             settingName: element[0],

--- a/theme.qml
+++ b/theme.qml
@@ -68,6 +68,16 @@ FocusScope {
             BTNRT:glyphs.uInputBtnRt,
             BTNU: glyphs.uInputBtnU
         },
+        "Japanese": {
+            BTND: glyphs.uInputBtnR,
+            BTNL: glyphs.uInputBtnU,
+            BTNLB: glyphs.uInputBtnLb,
+            BTNLT: glyphs.uInputBtnLt,
+            BTNR: glyphs.uInputBtnD,
+            BTNRB: glyphs.uInputBtnRb,
+            BTNRT:glyphs.uInputBtnRt,
+            BTNU: glyphs.uInputBtnL
+        },
         "XBOX": {
             BTND: glyphs.xInputBtnD,
             BTNL: glyphs.xInputBtnL,

--- a/theme.qml
+++ b/theme.qml
@@ -68,7 +68,7 @@ FocusScope {
             BTNRT:glyphs.uInputBtnRt,
             BTNU: glyphs.uInputBtnU
         },
-        "Japanese": {
+        "Universal-JP": {
             BTND: glyphs.uInputBtnR,
             BTNL: glyphs.uInputBtnU,
             BTNLB: glyphs.uInputBtnLb,


### PR DESCRIPTION
Up until the PS5, the 4-button control meanings were flipped - i.e., ⭕ was confirm and ✖️ was cancel. [See here.](https://kotaku.com/what-do-the-buttons-on-the-playstation-controller-mean-5622270)

This PR adds a new variant of the Universal control scheme where the down and right buttons are flipped, and the up and left buttons are flipped. This also fits with the "Odin" control scheme on the Ayn Odin - as opposed to the Xbox control scheme, the other option.