### PR TITLE
Flip favorite and multiplayer button hints

### DIFF
--- a/Games/Games.qml
+++ b/Games/Games.qml
@@ -670,19 +670,6 @@ FocusScope {
                 }
 
                 Controls {
-                    id: button_L
-
-                    message: currentGame !== null && currentGame.favorite ? dataText[lang].games_removeFavorite : dataText[lang].games_addFavorite
-
-                    text_color: colorScheme[theme].details
-                    front_color: colorScheme[theme].details.replace(/#/g, "#26");
-                    back_color: colorScheme[theme].details.replace(/#/g, "#26");
-                    input_button: osdScheme[controlScheme].BTNL
-
-                    visible: currentGame !== null
-                }
-
-                Controls {
                     id: button_U
 
                     message: {
@@ -696,6 +683,19 @@ FocusScope {
                     front_color: colorScheme[theme].filters.replace(/#/g, "#26");
                     back_color: colorScheme[theme].filters.replace(/#/g, "#26");
                     input_button: osdScheme[controlScheme].BTNU
+                }
+
+                Controls {
+                    id: button_L
+
+                    message: currentGame !== null && currentGame.favorite ? dataText[lang].games_removeFavorite : dataText[lang].games_addFavorite
+
+                    text_color: colorScheme[theme].details
+                    front_color: colorScheme[theme].details.replace(/#/g, "#26");
+                    back_color: colorScheme[theme].details.replace(/#/g, "#26");
+                    input_button: osdScheme[controlScheme].BTNL
+
+                    visible: currentGame !== null
                 }
             }
 


### PR DESCRIPTION
When flipping between the different filters on a game view page, the “favourite” button hint appears and disappears, causing the button hints to move unnecessarily:

![9B87240E-6424-4A81-A23D-1ADA416BB5FC](https://user-images.githubusercontent.com/709492/178763471-04c41290-e879-46a2-83d2-c1c8bf7d5915.gif)

This change flips the two, so that this jumping around no longer occurs
