### PR TITLE
Fix the favorite icon vertical alignment when using screenshot grid

### DIFF
--- a/Games/GameItemGridScreenshot.qml
+++ b/Games/GameItemGridScreenshot.qml
@@ -145,6 +145,7 @@ Item {
             FavoriteIcon {
                 id: faveicon
                 parentImageWidth: screenshot.width
+                parentImageHeight: screenshot.height
             }
 
             CompletedIcon {


### PR DESCRIPTION
On the screenshot grid the favorite icon is centered vertically, add the height parameter so it sits in the top right corner of the image