### PR TITLE
When viewing the All Games / Favorites or Last Played collections, ma…

### DIFF
--- a/Games/Games.qml
+++ b/Games/Games.qml
@@ -281,7 +281,7 @@ FocusScope {
                                         pixelSize: vpx(14)
                                     }
                                     color: text_color
-                                    visible: customCollection && systemName !== ""
+                                    visible: showPlatformName()
                                 }
 
                                 Text {
@@ -292,7 +292,7 @@ FocusScope {
                                         pixelSize: vpx(14)
                                     }
                                     color: text_color
-                                    visible: customCollection && systemName !== ""
+                                    visible: showPlatformName()
                                 }
                             }
 
@@ -881,6 +881,13 @@ FocusScope {
         } else {
             return sortLabels[sortField];
         }
+    }
+
+    function showPlatformName() {
+        return (customCollection && systemName !== "") || 
+               (currentCollection.shortName === "all") || 
+               (currentCollection.shortName === "favorites") || 
+               (currentCollection.shortName === "lastplayed") ? true : false;
     }
 
 }

--- a/Games/Games.qml
+++ b/Games/Games.qml
@@ -14,7 +14,7 @@ FocusScope {
     readonly property string collectionType: currentCollection.extra.collectiontype !== undefined ? currentCollection.extra.collectiontype.toString() : 'System'
     readonly property var customSystemLogoCategories: ['Custom', 'Series']
     readonly property bool customCollection: customSystemLogoCategories.includes(collectionType)
-    readonly property string systemName: (currentGame !== null && dataConsoles[currentGame.extra.system] !== undefined) ? dataConsoles[currentGame.extra.system].fullName : ""
+    readonly property string systemName: (currentGame !== null && dataConsoles[currentGame.extra.system] !== undefined) ? dataConsoles[currentGame.extra.system].fullName : currentGame.collections.get(0).name
 
     property string clearedShortname: clearShortname(currentCollection.shortName)
     readonly property string alt_color2: (dataConsoles[clearedShortname] !== undefined) ? dataConsoles[clearedShortname].altColor2 : dataConsoles["default"].altColor2
@@ -281,6 +281,7 @@ FocusScope {
                                         pixelSize: vpx(14)
                                     }
                                     color: text_color
+
                                     visible: showPlatformName()
                                 }
 
@@ -292,6 +293,7 @@ FocusScope {
                                         pixelSize: vpx(14)
                                     }
                                     color: text_color
+
                                     visible: showPlatformName()
                                 }
                             }

--- a/theme.qml
+++ b/theme.qml
@@ -401,7 +401,7 @@ FocusScope {
             collectionDetails_gamesAvailable: "Spiele verfügbar",
             games_na: "K.A.",
             games_developedBy: "Entwickelt von",
-            games_for: "zum",
+            games_for: "für",
             games_players: "SPIELER",
             games_player: "1 SPIELER",
             games_favorited: "FAVORISIERT",


### PR DESCRIPTION
…ke the text that shows the game platform visible as an extension of the Developer line in the game details section (ex. "Developed by Capcom for Sega Dreamcast" etc. )

This is already implemented functionality for custom collections, just extending the logic for showing/hiding this text to include these 3 auto-created collections.

This could help resolve issue #64 